### PR TITLE
feat(module): support bandwidth package peer attachments

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,6 +8,20 @@ provider "alicloud" {
   region = "cn-shenzhen"
 }
 
+resource "alicloud_cen_bandwidth_package" "example" {
+  provider                   = alicloud.local_region
+  bandwidth                  = 5
+  cen_bandwidth_package_name = "tf-cen-cross-region-with-qos"
+  geographic_region_a_id     = "China"
+  geographic_region_b_id     = "China"
+  payment_type               = "PostPaid"
+}
+
+resource "alicloud_cen_bandwidth_package_attachment" "example" {
+  provider             = alicloud.local_region
+  instance_id          = module.complete.cen_instance_id
+  bandwidth_package_id = alicloud_cen_bandwidth_package.example.id
+}
 
 module "complete" {
   source = "../.."
@@ -24,4 +38,9 @@ module "complete" {
 
   traffic_qos_policy_and_queues = var.traffic_qos_policy_and_queues
 
+  tr_peer_attachment = {
+    bandwidth_type           = "BandwidthPackage"
+    bandwidth                = 5
+    cen_bandwidth_package_id = alicloud_cen_bandwidth_package_attachment.example.bandwidth_package_id
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,7 @@ resource "alicloud_cen_transit_router_peer_attachment" "this" {
   auto_publish_route_enabled     = var.tr_peer_attachment.auto_publish_route_enabled
   bandwidth_type                 = var.tr_peer_attachment.bandwidth_type
   bandwidth                      = var.tr_peer_attachment.bandwidth
+  cen_bandwidth_package_id       = var.tr_peer_attachment.cen_bandwidth_package_id
   transit_router_attachment_name = var.tr_peer_attachment.transit_router_attachment_name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,7 @@ variable "tr_peer_attachment" {
     route_table_association_enabled = optional(bool, true)
     bandwidth_type                  = optional(string, "DataTransfer")
     bandwidth                       = optional(number, 100)
+    cen_bandwidth_package_id        = optional(string, null)
   })
   default = {}
 }


### PR DESCRIPTION
## Summary

Add support for CEN bandwidth-package-backed transit router peer attachments.

## Changes

- add optional public input `tr_peer_attachment.cen_bandwidth_package_id`
- pass the value to `alicloud_cen_transit_router_peer_attachment`
- update the complete example to create and attach a bandwidth package

## Compatibility and release impact

This expands the module's public input object, so it is a feature rather than a regression fix. Expected release impact: **MINOR**.

## Validation

The commit subject was corrected to `feat(module): support bandwidth package peer attachments` at head `2c32e3859e8c0db0ddbb5014f5901ddda0d2fc73`.

The rewritten head has a non-empty check set with all 6 checks completed successfully, including E2E. The PR has therefore returned to Ready for review.
